### PR TITLE
Paging data in stores

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mediakular/gridcraft",
-  "version": "0.1.3",
+  "version": "0.2.0-beta",
   "scripts": {
     "dev": "vite dev",
     "build": "vite build && npm run package",

--- a/src/lib/GridFunctions.ts
+++ b/src/lib/GridFunctions.ts
@@ -1,5 +1,6 @@
 import { hash } from "./helpers/hash-helper.js";
-import type { GridColumn, GridFilter, GroupHeader } from "./types/index.js";
+import PagingStore from "./stores/PagingStore.js";
+import type { GridColumn, GridFilter, GroupHeader, IPagingData } from "./types/index.js";
 
 export class GridFunctions<T> {
     public data: T[] = [];
@@ -17,6 +18,12 @@ export class GridFunctions<T> {
     init(data: T[]) : GridFunctions<T> {
         this.data = data;
         this.dataLength = this.data.length;
+
+        PagingStore.update((value:IPagingData) => {
+            value.totalResults = this.dataLength;
+            return value;
+        });
+
         return this;
     }
 
@@ -61,8 +68,6 @@ export class GridFunctions<T> {
             }
             return true;
         })
-
-        this.dataLength = this.data.length;
 
         return this;
     }
@@ -135,6 +140,12 @@ export class GridFunctions<T> {
             const endIndex = startIndex + itemsPerPage;
 
             this.data = this.data.slice(startIndex, endIndex);
+
+            PagingStore.update((value:IPagingData) => {
+                value.totalPages = Math.max(1, Math.ceil(value.totalResults / Math.max(1, value.itemsPerPage)));
+                return value;
+            });
+            
             return this;
         }
 
@@ -253,6 +264,12 @@ export class GridFunctions<T> {
         });
         
         this.dataLength = groupDataLength;
+
+        PagingStore.update((value:IPagingData) => {
+            value.totalResults = this.dataLength;
+            value.totalPages = Math.max(1, Math.ceil(value.totalResults / Math.max(1, value.itemsPerPage)));
+            return value;
+        });
 
         return this;
     }

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -1,15 +1,9 @@
 <script lang="ts">
-    import PlainTableTheme from "$lib/themes/plain-table/index.js";
-    import type { GridTheme } from "$lib/types/index.js";
+    import ThemeStore from '$lib/stores/ThemeStore.js';
 
-    export let theme: GridTheme = PlainTableTheme;
-    export let currentPage = 1;
-    export let totalPages = 1;
-    export let totalResults = 1;
-    export let itemsPerPage = 10;
-    export let itemsPerPageOptions = [10, 20, 50, 100];
+    $: theme = $ThemeStore;
 </script>
 
-<svelte:component this={theme.footer} bind:currentPage={currentPage} bind:totalPages={totalPages} bind:totalResults={totalResults} bind:itemsPerPage={itemsPerPage} bind:itemsPerPageOptions={itemsPerPageOptions}>
-    <svelte:component this={theme.paging} bind:currentPage={currentPage} bind:totalPages={totalPages} />
+<svelte:component this={theme.footer}>
+    <svelte:component this={theme.paging}/>
 </svelte:component>

--- a/src/lib/components/Grid.svelte
+++ b/src/lib/components/Grid.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-    import PlainTableCssTheme from "$lib/themes/plain-table/index.js";
+    import PagingStore from '$lib/stores/PagingStore.js';
+    import ThemeStore from '$lib/stores/ThemeStore.js';
 
 	import { GridFunctions } from "../GridFunctions.js";
-    import type { GridColumn, GridFilter, GridTheme, GroupHeader } from "$lib/types/index.js";
+    import type { GridColumn, GridFilter, GroupHeader } from "$lib/types/index.js";
 
     type T = $$Generic<any>;
     type ExpandedGroups = { [value:string] : boolean };
@@ -14,24 +15,19 @@
 
     export let groupBy = ""; // Default grouping column
     export let sortByColumn = "";
-    export let itemsPerPage = 10;
     export let sortOrder = 1; // 1 for ascending, -1 for descending
-    export let currentPage = 1;
-    export let totalPages = 0;
-    export let totalResults = 0;
+
     export let showCheckboxes = false;
     export let groupsExpandedDefault = true;
     export let selectedRows: T[] = [];
 
-    export let theme: GridTheme = PlainTableCssTheme;
-
-    $: theme;
+    $: paging = $PagingStore;
+    $: theme = $ThemeStore;
 
     let sortOrderSecondary = 1; // 1 for ascending, -1 for descending
     let expandedGroups: ExpandedGroups = {};
 
     $: fulldata = Array.from(data);
-
     $: columns, assignAutoColumns();
 
     function assignAutoColumns() {
@@ -54,19 +50,19 @@
             col.visible = true;
         }
     })
+
     $: grid = new GridFunctions<T>()
         .init(fulldata)
         .applyFilters(filters, columns)
         .sortBy(sortByColumn, sortOrder, groupBy, sortOrderSecondary, columns)
         .groupBy(groupBy, expandedGroups, groupsExpandedDefault, columns)
-        .processPaging(currentPage, itemsPerPage, groupBy, columns);
+        .processPaging(paging.currentPage, paging.itemsPerPage, groupBy, columns);
     $: gridData = grid.data;
     $: dataUnpaged = grid.dataUnpaged;
-    $: totalResults = grid.dataLength;
+
     $: groupHeaders = grid.groupHeaders;
     $: groupHeadersUnpaged = grid.groupHeadersUnpaged;
-    $: totalPages = Math.max(1, Math.ceil(totalResults / Math.max(1, itemsPerPage)));
-
+    
     function handleSort(column: string) {
         if (groupBy) {
             if (column === sortByColumn) {

--- a/src/lib/components/Paging.svelte
+++ b/src/lib/components/Paging.svelte
@@ -1,11 +1,7 @@
 <script lang="ts">
-    import PlainTableTheme from "$lib/themes/plain-table/index.js";
-    import type { GridTheme } from "$lib/types/index.js";
+    import ThemeStore from '$lib/stores/ThemeStore.js';
 
-    export let theme: GridTheme = PlainTableTheme;
-
-    export let currentPage = 1;
-    export let totalPages = 1;
+    $: theme = $ThemeStore;
 </script>
 
-<svelte:component this={theme.paging} bind:currentPage={currentPage} bind:totalPages={totalPages} />
+<svelte:component this={theme.paging} />

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -4,6 +4,10 @@ import Grid from './components/Grid.svelte';
 import GridFooter from './components/Footer.svelte';
 import GridPaging from './components/Paging.svelte';
 
+import PagingStore from "./stores/pagingStore.js";
+import ThemeStore from "./stores/themeStore.js";
+import type { IPagingData } from "./types/index.js";
+
 import PlainTableTheme from './themes/plain-table/index.js';
 import PrelineTheme from './themes/preline/index.js';
 import PlainTableCssTheme from './themes/plain-table-css/index.js';
@@ -19,6 +23,9 @@ export {
     GridFilter, 
     GroupHeader,
     GridTheme,
+    ThemeStore,
+    PagingStore,
+    IPagingData,
     PlainTableTheme,
     PrelineTheme,
     PlainTableCssTheme,

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -4,9 +4,9 @@ import Grid from './components/Grid.svelte';
 import GridFooter from './components/Footer.svelte';
 import GridPaging from './components/Paging.svelte';
 
-import PagingStore from "./stores/pagingStore.js";
-import ThemeStore from "./stores/themeStore.js";
-import type { IPagingData } from "./types/index.js";
+import PagingStore from "./stores/PagingStore.js";
+import ThemeStore from "./stores/ThemeStore.js";
+import type { PagingData } from "./types/index.js";
 
 import PlainTableTheme from './themes/plain-table/index.js';
 import PrelineTheme from './themes/preline/index.js';
@@ -23,9 +23,9 @@ export {
     GridFilter, 
     GroupHeader,
     GridTheme,
+    PagingData,
     ThemeStore,
     PagingStore,
-    IPagingData,
     PlainTableTheme,
     PrelineTheme,
     PlainTableCssTheme,

--- a/src/lib/stores/pagingStore.ts
+++ b/src/lib/stores/pagingStore.ts
@@ -1,0 +1,12 @@
+import type { IPagingData } from '$lib/types/index.js';
+import { writable } from 'svelte/store';
+ 
+const PagingStore = writable<IPagingData>({
+    currentPage: 1,
+    totalPages: 1,
+    totalResults: 0,
+    itemsPerPage: 10,
+    itemsPerPageOptions: [10, 25, 50, 100] 
+});
+ 
+export default PagingStore;

--- a/src/lib/stores/themeStore.ts
+++ b/src/lib/stores/themeStore.ts
@@ -1,0 +1,7 @@
+import PlainTableCssTheme from '$lib/themes/plain-table-css/index.js';
+import type { GridTheme } from '$lib/types/index.js';
+import { writable } from 'svelte/store';
+ 
+const ThemeStore = writable<GridTheme>(PlainTableCssTheme);
+ 
+export default ThemeStore;

--- a/src/lib/themes/cards-plus/footer/Footer.svelte
+++ b/src/lib/themes/cards-plus/footer/Footer.svelte
@@ -1,31 +1,43 @@
 <script lang="ts">
-	import Paging from "../paging/Paging.svelte";
+    import PagingStore from "$lib/stores/PagingStore.js";
+    import type { IPagingData } from "$lib/types/index.js";
 
-    export let currentPage = 1;
-    export let totalPages = 1;
-    export let totalResults = 0;
-    export let itemsPerPage = 10;
-    export let itemsPerPageOptions = [10, 20, 50, 100];
+    $: paging = $PagingStore;
+
+    function handleItemsPerPageChange() {
+        PagingStore.update((value:IPagingData) => {
+            
+            const totalPages = Math.max(1, Math.ceil(paging.totalResults / Math.max(1, paging.itemsPerPage)));
+            const currentPage = Math.max(1, Math.min(paging.currentPage, totalPages));
+
+            return {
+                ...value, 
+                currentPage: currentPage,
+                totalPages: totalPages, 
+                itemsPerPage: paging.itemsPerPage
+            }; 
+        });
+    }
 </script>
 
 
 <div class="px-6 py-4 grid gap-3 md:flex md:justify-between md:items-center">
     <div class="inline-flex items-center gap-x-2">
         <div class="max-w-sm space-y-3">
-            <select bind:value={itemsPerPage} class="py-2 px-3 pr-9 block w-full border-gray-200 rounded-md text-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-slate-900 dark:border-gray-700 dark:text-gray-400" >
-                {#each itemsPerPageOptions as option (option)}                
-                    <option value="{option}" selected={option == itemsPerPage}>{option}</option>
+            <select bind:value={paging.itemsPerPage} on:change={handleItemsPerPageChange} class="py-2 px-3 pr-9 block w-full border-gray-200 rounded-md text-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-slate-900 dark:border-gray-700 dark:text-gray-400" >
+                {#each paging.itemsPerPageOptions as option (option)}                
+                    <option value="{option}" selected={option == paging.itemsPerPage}>{option}</option>
                 {/each}
             </select>
         </div>
         <p class="text-sm text-gray-600 dark:text-gray-400">
-          of <span class="font-semibold text-gray-800 dark:text-gray-200">{totalResults}</span> Results
+          of <span class="font-semibold text-gray-800 dark:text-gray-200">{paging.totalResults}</span> Results
         </p>
     </div>
 
     <p class="text-sm text-gray-600 dark:text-gray-400">
-        Page <span class="font-semibold text-gray-800 dark:text-gray-200">{currentPage}</span> of <span class="font-semibold text-gray-800 dark:text-gray-200">{totalPages}</span>
+        Page <span class="font-semibold text-gray-800 dark:text-gray-200">{paging.currentPage}</span> of <span class="font-semibold text-gray-800 dark:text-gray-200">{paging.totalPages}</span>
     </p>
 
-    <Paging bind:currentPage bind:totalPages />
+    <slot />
 </div>

--- a/src/lib/themes/cards-plus/paging/Paging.svelte
+++ b/src/lib/themes/cards-plus/paging/Paging.svelte
@@ -1,32 +1,38 @@
 <script lang="ts">
-    export let currentPage = 1;
-    export let totalPages = 1;
+    import PagingStore from "$lib/stores/PagingStore.js";
+    import type { IPagingData } from "$lib/types/index.js";
 
-    $: currentPage = Math.max(1, Math.min(currentPage, totalPages));
+    $: paging = $PagingStore;
 
     function nextPage() {
-        if (currentPage < totalPages) {
-            currentPage += 1;
-        }
+        PagingStore.update((value:IPagingData) => {
+            return {
+                ...value,
+                currentPage: value.currentPage += 1
+            };
+        })
     }
 
     function prevPage() {
-        if (currentPage > 1) {
-            currentPage -= 1;
-        }
+        PagingStore.update((value:IPagingData) => {
+            return {
+                ...value,
+                currentPage: value.currentPage -= 1
+            };
+        })
     }
 </script>
 
 <div>
     <div class="inline-flex gap-x-2">
-        <button on:click={prevPage} type="button" disabled={currentPage == 1 ? true : false} class="py-2 px-3 inline-flex justify-center items-center gap-2 rounded-md border font-medium bg-white text-gray-700 shadow-sm align-middle hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-white focus:ring-blue-600 transition-all text-sm dark:bg-slate-900 dark:hover:bg-slate-800 dark:border-gray-700 dark:text-gray-400 dark:hover:text-white dark:focus:ring-offset-gray-800 disabled:opacity-40">
+        <button on:click={prevPage} type="button" disabled={paging.currentPage == 1 ? true : false} class="py-2 px-3 inline-flex justify-center items-center gap-2 rounded-md border font-medium bg-white text-gray-700 shadow-sm align-middle hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-white focus:ring-blue-600 transition-all text-sm dark:bg-slate-900 dark:hover:bg-slate-800 dark:border-gray-700 dark:text-gray-400 dark:hover:text-white dark:focus:ring-offset-gray-800 disabled:opacity-40">
             <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
             <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z"/>
             </svg>
             Previous
         </button>
 
-        <button on:click={nextPage} type="button" disabled={currentPage < totalPages ? false : true} class="py-2 px-3 inline-flex justify-center items-center gap-2 rounded-md border font-medium bg-white text-gray-700 shadow-sm align-middle hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-white focus:ring-blue-600 transition-all text-sm dark:bg-slate-900 dark:hover:bg-slate-800 dark:border-gray-700 dark:text-gray-400 dark:hover:text-white dark:focus:ring-offset-gray-800 disabled:opacity-40">
+        <button on:click={nextPage} type="button" disabled={paging.currentPage < paging.totalPages ? false : true} class="py-2 px-3 inline-flex justify-center items-center gap-2 rounded-md border font-medium bg-white text-gray-700 shadow-sm align-middle hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-white focus:ring-blue-600 transition-all text-sm dark:bg-slate-900 dark:hover:bg-slate-800 dark:border-gray-700 dark:text-gray-400 dark:hover:text-white dark:focus:ring-offset-gray-800 disabled:opacity-40">
             Next
             <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
                 <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z"/>

--- a/src/lib/themes/plain-table-css/footer/Footer.svelte
+++ b/src/lib/themes/plain-table-css/footer/Footer.svelte
@@ -1,22 +1,34 @@
 <script lang="ts">
-    export let currentPage = 1;
-    export let totalPages = 1;
-    export let totalResults = 0;
-    export let itemsPerPage = 10;
-    export let itemsPerPageOptions = [10, 20, 50, 100];
-</script>
+    import PagingStore from "$lib/stores/PagingStore.js";
+    import type { IPagingData } from "$lib/types/index.js";
 
+    $: paging = $PagingStore;
+
+    function handleItemsPerPageChange() {
+        PagingStore.update((value:IPagingData) => {
+            const totalPages = Math.max(1, Math.ceil(paging.totalResults / Math.max(1, paging.itemsPerPage)));
+            const currentPage = Math.max(1, Math.min(paging.currentPage, totalPages));
+
+            return {
+                ...value, 
+                currentPage: currentPage,
+                totalPages: totalPages, 
+                itemsPerPage: paging.itemsPerPage
+            }; 
+        });
+    }
+</script>
 
 <div class="gc-footer">
     <span>Rows per page</span>
 
-    <select bind:value={itemsPerPage}>
-        {#each itemsPerPageOptions as option (option)}                
-            <option value="{option}" selected={option == itemsPerPage}>{option}</option>
+    <select bind:value={paging.itemsPerPage} on:change={handleItemsPerPageChange}>
+        {#each paging.itemsPerPageOptions as option (option)}                
+            <option value="{option}" selected={option == paging.itemsPerPage}>{option}</option>
         {/each}
     </select>
 
-    <span>{currentPage * itemsPerPage - itemsPerPage + 1} - {currentPage * itemsPerPage}  of {totalResults}</span>
+    <span>{paging.currentPage * paging.itemsPerPage - paging.itemsPerPage + 1} - {paging.currentPage * paging.itemsPerPage} of {paging.totalResults}</span>
 
     <slot />
 </div>

--- a/src/lib/themes/plain-table-css/paging/Paging.svelte
+++ b/src/lib/themes/plain-table-css/paging/Paging.svelte
@@ -1,31 +1,37 @@
 <script lang="ts">
-    export let currentPage = 1;
-    export let totalPages = 1;
+    import PagingStore from "$lib/stores/PagingStore.js";
+    import type { IPagingData } from "$lib/types/index.js";
 
-    $: currentPage = Math.max(1, Math.min(currentPage, totalPages));
+    $: paging = $PagingStore;
 
     function nextPage() {
-        if (currentPage < totalPages) {
-            currentPage += 1;
-        }
+        PagingStore.update((value:IPagingData) => {
+            return {
+                ...value,
+                currentPage: value.currentPage += 1
+            };
+        })
     }
 
     function prevPage() {
-        if (currentPage > 1) {
-            currentPage -= 1;
-        }
+        PagingStore.update((value:IPagingData) => {
+            return {
+                ...value,
+                currentPage: value.currentPage -= 1
+            };
+        })
     }
 </script>
 
 <div class="gc-paging">
-    <button on:click={prevPage} type="button" disabled={currentPage == 1 ? true : false} >
+    <button on:click={prevPage} type="button" disabled={paging.currentPage == 1 ? true : false} >
         <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
             <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z"/>
         </svg>
         Previous
     </button>
 
-    <button on:click={nextPage} type="button" disabled={currentPage < totalPages ? false : true}>
+    <button on:click={nextPage} type="button" disabled={paging.currentPage < paging.totalPages ? false : true}>
         Next
         <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
             <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z"/>

--- a/src/lib/themes/plain-table/footer/Footer.svelte
+++ b/src/lib/themes/plain-table/footer/Footer.svelte
@@ -1,21 +1,34 @@
 <script lang="ts">
-    export let currentPage = 1;
-    export let totalPages = 1;
-    export let totalResults = 0;
-    export let itemsPerPage = 10;
-    export let itemsPerPageOptions = [10, 20, 50, 100];
+    import PagingStore from "$lib/stores/PagingStore.js";
+    import type { IPagingData } from "$lib/types/index.js";
+
+    $: paging = $PagingStore;
+
+    function handleItemsPerPageChange() {
+        PagingStore.update((value:IPagingData) => {
+            
+            const totalPages = Math.max(1, Math.ceil(paging.totalResults / Math.max(1, paging.itemsPerPage)));
+            const currentPage = Math.max(1, Math.min(paging.currentPage, totalPages));
+
+            return {
+                ...value, 
+                currentPage: currentPage,
+                totalPages: totalPages, 
+                itemsPerPage: paging.itemsPerPage
+            }; 
+        });
+    }
 </script>
 
-
 <div>
-    <select bind:value={itemsPerPage}>
-        {#each itemsPerPageOptions as option (option)}                
-            <option value="{option}" selected={option == itemsPerPage}>{option}</option>
+    <select bind:value={paging.itemsPerPage} on:change={handleItemsPerPageChange}>
+        {#each paging.itemsPerPageOptions as option (option)}                
+            <option value="{option}" selected={option == paging.itemsPerPage}>{option}</option>
         {/each}
     </select>
-    <span>of {totalResults} Results</span>
+    <span>of {paging.totalResults} Results</span>
 
-    <span>Page {currentPage} of {totalPages}</span>
+    <span>Page {paging.currentPage} of {paging.totalPages}</span>
 
     <slot />
 </div>

--- a/src/lib/themes/plain-table/paging/Paging.svelte
+++ b/src/lib/themes/plain-table/paging/Paging.svelte
@@ -1,31 +1,37 @@
 <script lang="ts">
-    export let currentPage = 1;
-    export let totalPages = 1;
+    import PagingStore from "$lib/stores/PagingStore.js";
+    import type { IPagingData } from "$lib/types/index.js";
 
-    $: currentPage = Math.max(1, Math.min(currentPage, totalPages));
+    $: paging = $PagingStore;
 
     function nextPage() {
-        if (currentPage < totalPages) {
-            currentPage += 1;
-        }
+        PagingStore.update((value:IPagingData) => {
+            return {
+                ...value,
+                currentPage: value.currentPage += 1
+            };
+        })
     }
 
     function prevPage() {
-        if (currentPage > 1) {
-            currentPage -= 1;
-        }
+        PagingStore.update((value:IPagingData) => {
+            return {
+                ...value,
+                currentPage: value.currentPage -= 1
+            };
+        })
     }
 </script>
 
 <div>
-    <button on:click={prevPage} type="button" disabled={currentPage == 1 ? true : false} >
+    <button on:click={prevPage} type="button" disabled={paging.currentPage == 1 ? true : false} >
         <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
             <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z"/>
         </svg>
         Previous
     </button>
 
-    <button on:click={nextPage} type="button" disabled={currentPage < totalPages ? false : true}>
+    <button on:click={nextPage} type="button" disabled={paging.currentPage < paging.totalPages ? false : true}>
         Next
         <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
             <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z"/>

--- a/src/lib/themes/preline/footer/Footer.svelte
+++ b/src/lib/themes/preline/footer/Footer.svelte
@@ -1,31 +1,42 @@
 <script lang="ts">
-	import Paging from "../paging/Paging.svelte";
+    import PagingStore from "$lib/stores/PagingStore.js";
+    import type { IPagingData } from "$lib/types/index.js";
 
-    export let currentPage = 1;
-    export let totalPages = 1;
-    export let totalResults = 0;
-    export let itemsPerPage = 10;
-    export let itemsPerPageOptions = [10, 20, 50, 100];
+    $: paging = $PagingStore;
+
+    function handleItemsPerPageChange() {
+        PagingStore.update((value:IPagingData) => {
+            const totalPages = Math.max(1, Math.ceil(paging.totalResults / Math.max(1, paging.itemsPerPage)));
+            const currentPage = Math.max(1, Math.min(paging.currentPage, totalPages));
+
+            return {
+                ...value, 
+                currentPage: currentPage,
+                totalPages: totalPages, 
+                itemsPerPage: paging.itemsPerPage
+            }; 
+        });
+    }
 </script>
 
 
 <div class="px-6 py-4 grid gap-3 md:flex md:justify-between md:items-center">
     <div class="inline-flex items-center gap-x-2">
         <div class="max-w-sm space-y-3">
-            <select bind:value={itemsPerPage} class="py-2 px-3 pr-9 block w-full border-gray-200 rounded-md text-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-slate-900 dark:border-gray-700 dark:text-gray-400" >
-                {#each itemsPerPageOptions as option (option)}                
-                    <option value="{option}" selected={option == itemsPerPage}>{option}</option>
+            <select bind:value={paging.itemsPerPage} on:change={handleItemsPerPageChange} class="py-2 px-3 pr-9 block w-full border-gray-200 rounded-md text-sm focus:border-blue-500 focus:ring-blue-500 dark:bg-slate-900 dark:border-gray-700 dark:text-gray-400" >
+                {#each paging.itemsPerPageOptions as option (option)}                
+                    <option value="{option}" selected={option == paging.itemsPerPage}>{option}</option>
                 {/each}
             </select>
         </div>
         <p class="text-sm text-gray-600 dark:text-gray-400">
-          of <span class="font-semibold text-gray-800 dark:text-gray-200">{totalResults}</span> Results
+          of <span class="font-semibold text-gray-800 dark:text-gray-200">{paging.totalResults}</span> Results
         </p>
     </div>
 
     <p class="text-sm text-gray-600 dark:text-gray-400">
-        Page <span class="font-semibold text-gray-800 dark:text-gray-200">{currentPage}</span> of <span class="font-semibold text-gray-800 dark:text-gray-200">{totalPages}</span>
+        Page <span class="font-semibold text-gray-800 dark:text-gray-200">{paging.currentPage}</span> of <span class="font-semibold text-gray-800 dark:text-gray-200">{paging.totalPages}</span>
     </p>
 
-    <Paging bind:currentPage bind:totalPages />
+    <slot />
 </div>

--- a/src/lib/themes/preline/paging/Paging.svelte
+++ b/src/lib/themes/preline/paging/Paging.svelte
@@ -1,32 +1,38 @@
 <script lang="ts">
-    export let currentPage = 1;
-    export let totalPages = 1;
+    import PagingStore from "$lib/stores/PagingStore.js";
+    import type { IPagingData } from "$lib/types/index.js";
 
-    $: currentPage = Math.max(1, Math.min(currentPage, totalPages));
+    $: paging = $PagingStore;
 
     function nextPage() {
-        if (currentPage < totalPages) {
-            currentPage += 1;
-        }
+        PagingStore.update((value:IPagingData) => {
+            return {
+                ...value,
+                currentPage: value.currentPage += 1
+            };
+        })
     }
 
     function prevPage() {
-        if (currentPage > 1) {
-            currentPage -= 1;
-        }
+        PagingStore.update((value:IPagingData) => {
+            return {
+                ...value,
+                currentPage: value.currentPage -= 1
+            };
+        })
     }
 </script>
 
 <div>
     <div class="inline-flex gap-x-2">
-        <button on:click={prevPage} type="button" disabled={currentPage == 1 ? true : false} class="py-2 px-3 inline-flex justify-center items-center gap-2 rounded-md border font-medium bg-white text-gray-700 shadow-sm align-middle hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-white focus:ring-blue-600 transition-all text-sm dark:bg-slate-900 dark:hover:bg-slate-800 dark:border-gray-700 dark:text-gray-400 dark:hover:text-white dark:focus:ring-offset-gray-800 disabled:opacity-40">
+        <button on:click={prevPage} type="button" disabled={paging.currentPage == 1 ? true : false} class="py-2 px-3 inline-flex justify-center items-center gap-2 rounded-md border font-medium bg-white text-gray-700 shadow-sm align-middle hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-white focus:ring-blue-600 transition-all text-sm dark:bg-slate-900 dark:hover:bg-slate-800 dark:border-gray-700 dark:text-gray-400 dark:hover:text-white dark:focus:ring-offset-gray-800 disabled:opacity-40">
             <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
             <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z"/>
             </svg>
             Previous
         </button>
 
-        <button on:click={nextPage} type="button" disabled={currentPage < totalPages ? false : true} class="py-2 px-3 inline-flex justify-center items-center gap-2 rounded-md border font-medium bg-white text-gray-700 shadow-sm align-middle hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-white focus:ring-blue-600 transition-all text-sm dark:bg-slate-900 dark:hover:bg-slate-800 dark:border-gray-700 dark:text-gray-400 dark:hover:text-white dark:focus:ring-offset-gray-800 disabled:opacity-40">
+        <button on:click={nextPage} type="button" disabled={paging.currentPage < paging.totalPages ? false : true} class="py-2 px-3 inline-flex justify-center items-center gap-2 rounded-md border font-medium bg-white text-gray-700 shadow-sm align-middle hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-white focus:ring-blue-600 transition-all text-sm dark:bg-slate-900 dark:hover:bg-slate-800 dark:border-gray-700 dark:text-gray-400 dark:hover:text-white dark:focus:ring-offset-gray-800 disabled:opacity-40">
             Next
             <svg class="w-3 h-3" xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
                 <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z"/>

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -55,7 +55,7 @@ export type GridTheme = {
     paging: ComponentType;
 }
 
-export interface IPagingData {
+export type PagingData = {
     currentPage: number;
     totalPages: number;
     totalResults: number;

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -54,3 +54,11 @@ export type GridTheme = {
     footer: ComponentType;
     paging: ComponentType;
 }
+
+export interface IPagingData {
+    currentPage: number;
+    totalPages: number;
+    totalResults: number;
+    itemsPerPage: number;
+    itemsPerPageOptions: number[];
+}


### PR DESCRIPTION
Paging data and theme are now stored in Svelte Stores.

This includes breaking changes. I removed the following properties from the `Grid`-Component: 
- Theme
- itemsPerPage
- currentPage
- totalPages
- totalResults
- itemsPerPageOptions

These can be now set via the two Stores `ThemeStore` and `PagingStore` which are exported